### PR TITLE
Jc hw issue12 sorted and color coded list items

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -20,3 +20,16 @@
 .App-link {
   color: #09d3ac;
 }
+
+.soon-list-items {
+  color: green;
+}
+.kinda-soon-list-items {
+  color: yellow;
+}
+.not-soon-list-items {
+  color: red;
+}
+.inactive-list-items {
+  color: grey;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -20,16 +20,3 @@
 .App-link {
   color: #09d3ac;
 }
-
-.soon-list-items {
-  color: green;
-}
-.kinda-soon-list-items {
-  color: yellow;
-}
-.not-soon-list-items {
-  color: red;
-}
-.inactive-list-items {
-  color: grey;
-}

--- a/src/components/AddItemForm/AddItemForm.js
+++ b/src/components/AddItemForm/AddItemForm.js
@@ -8,6 +8,8 @@ async function addToDb(item_name, purchase_interval, user_token) {
     const docRef = await addDoc(collection(db, 'groceries'), {
       item_name: item_name,
       purchase_interval: purchase_interval,
+      //changed prev estimate to initialize as purchase_interval
+      previous_estimate: purchase_interval,
       user_token: user_token,
       last_purchased_date: null,
       total_purchases: 0,

--- a/src/pages/ItemList.js
+++ b/src/pages/ItemList.js
@@ -155,7 +155,7 @@ function ItemList({ token }) {
 
             const inactiveItem =
               msToDay(now - doc.last_purchased_date) >=
-              doc.previous_estimate - 2;
+              doc.previous_estimate * 2;
 
             const itemStatus = () => {
               //assigns style based on purchase urgency

--- a/src/pages/ItemList.js
+++ b/src/pages/ItemList.js
@@ -167,33 +167,48 @@ function ItemList({ token }) {
             const wasCheckedInLast24Hours =
               now - doc.last_purchased_date < ONE_DAY;
 
-            const itemColor = () => {
+            const itemStatus = () => {
               //assigns style based on purchase urgency
-              //1.commented out first part of conditional bc it didn't fit our data... 0/1 && 2x past estimate?
-              //place inactive items into own map after active list?
-              if (
-                /*doc.total_purchases === 1 || */ msToDay(
-                  now - doc.last_purchased_date,
-                ) >=
-                2 * doc.previousEstimate
-              ) {
-                console.log('inactive');
-                return 'grey';
-              } else if (doc.previous_estimate > 30) {
+              //items are grey if purchased recently because of small estimate
+              // if (msToDay(now - doc.last_purchased_date,) >= 2 * doc.previous_estimate) {
+              //   console.log('inactive');
+              //   // return 'grey';
+              //   return {
+              //     color: 'grey',
+              //     label: 'inactive item'
+              //   }
+              // } else
+              if (doc.previous_estimate > 30) {
                 console.log('>30');
-                return 'red';
+                // return 'red';
+                return {
+                  color: 'red',
+                  label: `${doc.previous_estimate} days expected until purchase needed`,
+                };
               } else if (
                 doc.previous_estimate > 7 &&
                 doc.previous_estimate <= 30
               ) {
                 console.log('7-30');
-                return 'yellow';
+                // return 'yellow';
+                return {
+                  color: 'yellow',
+                  label: `${doc.previous_estimate} days expected until purchase needed`,
+                };
               } else if (doc.previous_estimate <= 7) {
                 console.log(7);
-                return 'green';
+                // return 'green';
+                return {
+                  color: 'green',
+                  label: `${doc.previous_estimate} days expected until purchase needed`,
+                };
               } else {
                 console.log('nothing');
-                return;
+                // return;
+                return {
+                  color: 'white',
+                  label: `buy in ${doc.previous_estimate} days`,
+                };
               }
             };
 
@@ -201,8 +216,9 @@ function ItemList({ token }) {
               <div
                 key={doc.id}
                 style={{
-                  backgroundColor: itemColor(),
+                  backgroundColor: itemStatus().color,
                 }}
+                aria-label={itemStatus().label}
               >
                 <label>
                   <input

--- a/src/pages/ItemList.js
+++ b/src/pages/ItemList.js
@@ -96,6 +96,19 @@ function ItemList({ token }) {
     fetchDocs(token);
   };
 
+  // conditional checks:
+
+  // if item < 7 days since last purchased
+  // return box as need to buy soon/color
+
+  // if item > 7 && < 30 days since last purchased
+  // return box as need to buy kind of soon/color
+
+  // if item > 30 days since last purchased
+  // return box as need to buy not so soon/color
+
+  // if item === inactive / item > last purchase >= 2x estimate
+  // return box as inactive
 
   //converts milliseconds to days
   function msToDay(ms) {
@@ -118,7 +131,18 @@ function ItemList({ token }) {
     return filteredData;
   };
 
-  const list = filterList();
+  const list = filterList().sort((item1, item2) => {
+    // console.log(item1)
+    // console.log(item2)
+
+    if (item1.previous_estimate > item2.previous_estimate) return 1;
+    if (item1.previous_estimate < item2.previous_estimate) return -1;
+
+    if (item1.item_name > item2.item_name) return 1;
+    if (item1.item_name < item2.item_name) return -1;
+  });
+
+  console.log(list);
 
   const handleSearchInputChange = (e) => {
     setSearchInput(e.target.value);

--- a/src/pages/ItemList.js
+++ b/src/pages/ItemList.js
@@ -169,10 +169,12 @@ function ItemList({ token }) {
 
             const itemColor = () => {
               //assigns style based on purchase urgency
-              //commented out first part of conditional bc it didn't fit our data
+              //1.commented out first part of conditional bc it didn't fit our data... 0/1 && 2x past estimate?
+              //place inactive items into own map after active list?
               if (
-                /*doc.total_purchases === 1 || */ now -
-                  doc.last_purchased_date >=
+                /*doc.total_purchases === 1 || */ msToDay(
+                  now - doc.last_purchased_date,
+                ) >=
                 2 * doc.previousEstimate
               ) {
                 console.log('inactive');

--- a/src/pages/ItemList.js
+++ b/src/pages/ItemList.js
@@ -135,11 +135,12 @@ function ItemList({ token }) {
     // console.log(item1)
     // console.log(item2)
 
-    if (item1.previous_estimate > item2.previous_estimate) return 1;
-    if (item1.previous_estimate < item2.previous_estimate) return -1;
+    if (item1.previous_estimate > item2.previous_estimate) return -1;
+    if (item1.previous_estimate < item2.previous_estimate) return 1;
 
-    if (item1.item_name > item2.item_name) return 1;
-    if (item1.item_name < item2.item_name) return -1;
+    if (item1.item_name.toLowerCase() > item2.item_name.toLowerCase()) return 1;
+    if (item1.item_name.toLowerCase() < item2.item_name.toLowerCase())
+      return -1;
   });
 
   console.log(list);
@@ -165,8 +166,42 @@ function ItemList({ token }) {
           {list.map((doc) => {
             const wasCheckedInLast24Hours =
               now - doc.last_purchased_date < ONE_DAY;
+
+            const itemColor = () => {
+              //assigns style based on purchase urgency
+              //commented out first part of conditional bc it didn't fit our data
+              if (
+                /*doc.total_purchases === 1 || */ now -
+                  doc.last_purchased_date >=
+                2 * doc.previousEstimate
+              ) {
+                console.log('inactive');
+                return 'grey';
+              } else if (doc.previous_estimate > 30) {
+                console.log('>30');
+                return 'red';
+              } else if (
+                doc.previous_estimate > 7 &&
+                doc.previous_estimate <= 30
+              ) {
+                console.log('7-30');
+                return 'yellow';
+              } else if (doc.previous_estimate <= 7) {
+                console.log(7);
+                return 'green';
+              } else {
+                console.log('nothing');
+                return;
+              }
+            };
+
             return (
-              <div key={doc.id}>
+              <div
+                key={doc.id}
+                style={{
+                  backgroundColor: itemColor(),
+                }}
+              >
                 <label>
                   <input
                     name={doc.item_name}

--- a/src/pages/ItemList.js
+++ b/src/pages/ItemList.js
@@ -19,7 +19,7 @@ const ONE_DAY = ONE_HOUR * 24;
 function ItemList({ token }) {
   const [docs, setDocs] = useState([]);
   const [searchInput, setSearchInput] = useState('');
-  const [now, setNow] = useState(Date.now());
+  const [now] = useState(Date.now());
   const [isLoading, setIsLoading] = useState(false);
 
   const fetchDocs = async (userToken) => {
@@ -96,20 +96,6 @@ function ItemList({ token }) {
     fetchDocs(token);
   };
 
-  // conditional checks:
-
-  // if item < 7 days since last purchased
-  // return box as need to buy soon/color
-
-  // if item > 7 && < 30 days since last purchased
-  // return box as need to buy kind of soon/color
-
-  // if item > 30 days since last purchased
-  // return box as need to buy not so soon/color
-
-  // if item === inactive / item > last purchase >= 2x estimate
-  // return box as inactive
-
   //converts milliseconds to days
   function msToDay(ms) {
     return (ms / (1000 * 60 * 60 * 24)).toFixed(1);
@@ -131,19 +117,18 @@ function ItemList({ token }) {
     return filteredData;
   };
 
+  // eslint-disable-next-line array-callback-return
   const list = filterList().sort((item1, item2) => {
     // console.log(item1)
     // console.log(item2)
 
-    if (item1.previous_estimate > item2.previous_estimate) return -1;
-    if (item1.previous_estimate < item2.previous_estimate) return 1;
+    if (item1.previous_estimate > item2.previous_estimate) return 1;
+    if (item1.previous_estimate < item2.previous_estimate) return -1;
 
     if (item1.item_name.toLowerCase() > item2.item_name.toLowerCase()) return 1;
     if (item1.item_name.toLowerCase() < item2.item_name.toLowerCase())
       return -1;
   });
-
-  console.log(list);
 
   const handleSearchInputChange = (e) => {
     setSearchInput(e.target.value);
@@ -165,39 +150,44 @@ function ItemList({ token }) {
           <button onClick={() => setSearchInput(() => '')}>Reset</button>
           {list.map((doc) => {
             const wasCheckedInLast24Hours =
+              // now - doc.last_purchased_date < ONE_SECOND;
               now - doc.last_purchased_date < ONE_DAY;
+
+            const inactiveItem =
+              msToDay(now - doc.last_purchased_date) >=
+              doc.previous_estimate - 2;
 
             const itemStatus = () => {
               //assigns style based on purchase urgency
               //items are grey if purchased recently because of small estimate
-              // if (msToDay(now - doc.last_purchased_date,) >= 2 * doc.previous_estimate) {
-              //   console.log('inactive');
-              //   // return 'grey';
-              //   return {
-              //     color: 'grey',
-              //     label: 'inactive item'
-              //   }
-              // } else
-              if (doc.previous_estimate > 30) {
-                console.log('>30');
-                // return 'red';
+              //45 days from now for testing
+              console.log(msToDay(now - 1648431178591)); //45 days ago 5/12/22**
+              if (
+                doc.last_purchased_date !== null &&
+                doc.previous_estimate !== 0 &&
+                inactiveItem
+              ) {
+                console.log('inactive');
+                return {
+                  color: 'grey',
+                  label: 'inactive item',
+                };
+              } else if (doc.previous_estimate >= 30) {
+                console.log('>= 30');
                 return {
                   color: 'red',
                   label: `${doc.previous_estimate} days expected until purchase needed`,
                 };
               } else if (
                 doc.previous_estimate > 7 &&
-                doc.previous_estimate <= 30
+                doc.previous_estimate < 30
               ) {
-                console.log('7-30');
-                // return 'yellow';
                 return {
                   color: 'yellow',
                   label: `${doc.previous_estimate} days expected until purchase needed`,
                 };
               } else if (doc.previous_estimate <= 7) {
                 console.log(7);
-                // return 'green';
                 return {
                   color: 'green',
                   label: `${doc.previous_estimate} days expected until purchase needed`,


### PR DESCRIPTION
## Description

For convenience & accessibility, this code adds color to each item depending on the when-to-order status. Once items are grouped by the status they are sorted alphabetically. 

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->
closes #12 

## Acceptance Criteria

- [x] Items in the list are shown as visually distinct (e.g., with a different background color on the list item) according to how soon the item is expected to be bought again: Soon, Kind of soon, Not soon, Inactive
- [x] Items should be sorted by the estimated number of days until the next purchase
- [x] Items with the same number of estimated days until next purchase should be sorted alphabetically
- [x] Items in the different states should be described distinctly when read by a screen reader

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

<!-- If UI feature, take provide screenshots -->
<img width="394" alt="Screen Shot 2022-05-12 at 9 04 50 PM" src="https://user-images.githubusercontent.com/88463344/168191257-eef5cbb5-c83d-4ff4-9457-800d4e01ece8.png">

### After

<!-- If UI feature, take provide screenshots -->
<img width="373" alt="Screen Shot 2022-05-12 at 9 05 13 PM" src="https://user-images.githubusercontent.com/88463344/168191314-e7274472-4aa3-48e4-bbe8-fb80f89659e4.png">


## Testing Steps / QA Criteria

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->
```git checkout jc-hw-issue12-sorted-and-color-coded-list-items```
```git pull```
```npm start```

When adding items, choose different purchase_intervals (soon, kind of soon, or not soon) and see how they are assigned different colors and are sorted. Once clicked and if not already green, the item should turn green indicating the item does *not* need to be bought soon.
